### PR TITLE
Added LTO

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,3 +4,4 @@
 - Carlo Meghini, Consiglio Nazionale delle Ricerche, IT,
 - Richard Zijdeman, International Institute of Social History, NL, University of Stirling, UK
 - Jacco van Ossenbruggen, CWI & VU Amsterdam
+- Paul Sheridan, University of Prince Edward Island (effective May 2022), CA

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This list collects useful ontologies, vocabularies, terminologies, and taxonomie
 - [Periodicals](#periodicals)
 - [Musicology](#musicology)
 - [Language](#language)
+- [Fiction studies](#fiction-studies)
 
 ## General
 *Persons, places, events, time, documents*
@@ -65,6 +66,8 @@ triple stores
 - [Lemon](http://lemon-model.net/) - Lemon is a proposed model for modeling lexicon and machine-readable dictionaries and linked to the Semantic Web and the Linked Data cloud
 - [Lexvo](http://www.lexvo.org/) - brings information about languages, words, characters, and other human language-related entities to the Linked Data Web and Semantic Web
 
+## Fiction Studies
+- [Literary Theme Ontology (LTO)](https://github.com/theme-ontology/theming) - a taxonomy of defined literary themes for thematically annotating works of fiction
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ triple stores
 - [Lexvo](http://www.lexvo.org/) - brings information about languages, words, characters, and other human language-related entities to the Linked Data Web and Semantic Web
 
 ## Fiction Studies
+*Film, literature, etc.*
 - [Literary Theme Ontology (LTO)](https://github.com/theme-ontology/theming) - a taxonomy of defined literary themes for thematically annotating works of fiction
 
 ## License


### PR DESCRIPTION
I went out on a limb and added a new "Fiction Studies" category. If you end up keeping it, here are a couple of possible additions:
- [Drammar](https://link.springer.com/chapter/10.1007/978-3-030-00668-6_7)
- [The Taxonomy of Themes and Motifs](https://digitalis-dsp.uc.pt/handle/10316.2/39095)

I'd be happy to add entries for them in another pull request. Just let me know!